### PR TITLE
configure jest to use ts-jest for processing typescript files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src/', '<rootDir>/tests/'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  },
+}; 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest --config jest.config.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Configure Jest to use ts-jest for TypeScript file processing.
Specify where to find test files.
Configure TypeScript transformer.